### PR TITLE
use label to separate the pipelines

### DIFF
--- a/trigger/git-issue-template.yaml
+++ b/trigger/git-issue-template.yaml
@@ -30,9 +30,10 @@ spec:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
-        name: $(params.repo_name)-issue-$(params.issue_number)-$(uid)
+        name: aicoe-issue-$(uid)
         labels:
           app: thoth-ci
+          project: $(params.repo_name)
           component: $(params.repo_name)-issue-$(params.issue_number)
       spec:
         serviceAccountName: thoth-ci

--- a/trigger/git-pr-template.yaml
+++ b/trigger/git-pr-template.yaml
@@ -37,10 +37,11 @@ spec:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
-        name: pipelinerun-$(params.pr_repo)-pr-$(params.pr_number)-$(uid)
+        name: aicoe-pipelinerun-$(uid)
         labels:
           app: thoth-ci
-          component: pipelinerun-$(params.pr_repo)-pr-$(params.pr_number)
+          project: $(params.pr_repo)
+          component: $(params.pr_repo)-pr-$(params.pr_number)
       spec:
         serviceAccountName: thoth-ci
         pipelineRef:

--- a/trigger/git-tag-template.yaml
+++ b/trigger/git-tag-template.yaml
@@ -22,6 +22,8 @@ spec:
         name: tag-release-$(params.repo_name)-$(uid)
         labels:
           app: thoth-ci
+          project: $(params.repo_name)
+          component: tag-$(params.repo_name)
       spec:
         serviceAccountName: thoth-ci
         pipelineRef:


### PR DESCRIPTION
use label to separate the pipelines
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #22 

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Due to the dns name schema followed by pipelinerun name, including the project names to the pipelinerun for the CI run on the project. hence keeping the pipelinerun to simple lowercase hyphen included naming convention.
using labels is a good method to separate or find the pipelinerun for a specific project.